### PR TITLE
feat: support TypedArrays in case we're not running on Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ CRC mathematics are mostly ported from https://pycrc.org/
 
 ## API
 
+Where available, this library supports:
+* Standard ECMAScript TypedArrays, DataView, ArrayBuffer
+* Legacy Node.js Buffers
+
 #### crc6(buffer)
 #### crc8(buffer)
 #### crc10(buffer)


### PR DESCRIPTION
This feature implements standard TypedArray support.

Both legacy Node.js Buffers and TypedArrays can be used, whatever is supported by the underlying platform.
