### PR TITLE
feat: allow bigints and non-negative numbers up to isSafeInteger (53 bits)

### DIFF
--- a/polycrc.js
+++ b/polycrc.js
@@ -12,6 +12,7 @@
 
 class CRC {
   constructor (width, poly, xor_in, xor_out, reflect) {
+    this.converter = makeBufferConverter()
     this.width = width
     this.poly = poly
     this.xor_in = xor_in
@@ -28,7 +29,7 @@ class CRC {
 
     if (this.width === 8 && !this.xor_in && !this.xor_out && !this.reflect) {
       this.calculate = function (buffer) {
-        buffer = validate_buffer(buffer)
+        buffer = this.converter.validate_buffer(buffer)
         let crc = 0
         for (let i = 0; i < buffer.length; i++) { crc = table[crc ^ buffer[i]] }
         return crc
@@ -37,7 +38,7 @@ class CRC {
   }
 
   calculate (buffer) {
-    buffer = validate_buffer(buffer)
+    buffer = this.converter.validate_buffer(buffer)
     let crc
     let { table, width, crc_shift, mask } = this
     if (this.reflect) {
@@ -60,7 +61,7 @@ class CRC {
   }
 
   calculate_no_table (buffer) {
-    buffer = validate_buffer(buffer)
+    buffer = this.converter.validate_buffer(buffer)
     let crc = this.xor_in
     for (let i = 0; i < buffer.length; i++) {
       let octet = buffer[i]
@@ -122,73 +123,104 @@ class CRC {
   }
 }
 
-const hasTypedArrays = typeof ArrayBuffer !== 'undefined' && typeof Uint8Array !== 'undefined'
 const hasBuffer = typeof Buffer !== 'undefined'
-if (!hasTypedArrays && !hasBuffer) {
+const hasTypedArrays = typeof ArrayBuffer !== 'undefined' && typeof Uint8Array !== 'undefined'
+
+const b256 = typeof BigInt !== undefined && BigInt(256)
+
+class BaseConverter {
+  validate_buffer (data) {
+    switch (typeof data) {
+      case 'number': {
+        if (!Number.isSafeInteger(data) || data < 0) {
+          throw Error(`number data must be a nonnegative safe integer, not ${data}`)
+        }
+
+        if (this.fromUInt32 && data <= 0xffffffff) {
+          return this.fromUInt32(data)
+        }
+
+        // Unpack the number into a big-endian array of 8-bit values.
+        const bytes = []
+
+        // For compatibility with polycrc@1.0.0, we make it at least 4 bytes in length.
+        // If we have a number more than 32 bits, we will have more bytes already.
+        while (data > 0 || bytes.length < 4) {
+          bytes.unshift(data % 256)
+          data = Math.floor(data / 256)
+        }
+
+        // Just create a buffer from that array.
+        return this.fromByteArray(bytes)
+      }
+      case 'string': {
+        return this.fromString(data)
+      }
+      case 'bigint': {
+        if (data < 0) {
+          throw Error(`bigint data must be nonnegative, not ${data}`)
+        }
+
+        // Unpack the bigint into a big-endian array of 8-bit values.
+        const bytes = []
+
+        // For compatibility with polycrc@1.0.0, we make it at least 4 bytes in length.
+        // If we have a number more than 32 bits, we will have more bytes already.
+        while (data > 0 || bytes.length < 4) {
+          bytes.unshift(Number(data % b256))
+          data /= b256
+        }
+        return this.fromByteArray(bytes)
+      }
+      default: {
+        // These conversions are not object methods because we want both
+        // BufferConverter and TypedArrayConverter to support whatever the
+        // platform is capable of.
+        if (hasBuffer && Buffer.isBuffer(data)) {
+          return data
+        }
+        if (hasTypedArrays) {
+          if (ArrayBuffer.isView(data)) {
+            return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+          }
+          if (data instanceof ArrayBuffer) {
+            return new Uint8Array(data)
+          }
+        }
+        throw new Error(`Unrecognized data type ${typeof data}: ${data}`)
+      }
+    }
+  }
+}
+
+// Convert most things to Buffers.
+class BufferConverter extends BaseConverter {
+  fromUInt32 (data) {
+    const buffer = Buffer.alloc(4)
+    buffer.writeUInt32BE(data)
+    return buffer
+  }
+
+  fromByteArray = Buffer.from.bind(Buffer)
+  fromString = Buffer.from.bind(Buffer)
+}
+
+// Convert most things to TypedArrays.
+class TypedArrayConverter extends BaseConverter {
+  fromByteArray = Uint8Array.from.bind(Uint8Array)
+  fromString (data) {
+    return new TextEncoder('utf-8').encode(data)
+  }
+}
+
+function makeBufferConverter (preferTypedArrays = false) {
+  if (hasTypedArrays && (preferTypedArrays || !hasBuffer)) {
+    return new TypedArrayConverter()
+  }
+  if (hasBuffer) {
+    return new BufferConverter()
+  }
   throw Error('either need TypedArrays or Buffer')
-}
-
-function fixUpNumberBytes (bytes) {
-  // For compatibility with polycrc@1.0.0, we make it at least 4 bytes in length.
-  // If we have a number more than 32 bits, we will have more bytes already.
-  while (bytes.length < 4) {
-    bytes.unshift(0)
-  }
-}
-
-function validate_buffer (data) {
-  switch (typeof data) {
-    case 'number':
-      if (!Number.isSafeInteger(data) || data < 0) {
-        throw Error(`number data must be a nonnegative safe integer, not ${data}`)
-      }
-      // Unpack the number into a big-endian array of 8-bit values.
-      const bytes = []
-      while (data > 0) {
-        bytes.unshift(data % 256)
-        data = Math.floor(data / 256)
-      }
-      fixUpNumberBytes(bytes)
-      // Just create a buffer from that array.
-      if (hasBuffer) {
-        return Buffer.from(bytes)
-      }
-      if (hasTypedArrays) {
-        return Uint8Array.from(bytes)
-      }
-      break
-    case 'string':
-      if (hasTypedArrays) {
-        return new TextEncoder('utf-8').encode(data)
-      } else if (hasBuffer) {
-        return Buffer.from(data)
-      }
-      break
-    case 'bigint':
-      const pairs = data.toString(16).match(/[\da-f]{2}/gi)
-      const ints = pairs.map(s => parseInt(s, 16))
-      fixUpNumberBytes(ints)
-      if (hasBuffer) {
-        return Buffer.from(ints)
-      } else if (hasTypedArrays) {
-        return new Uint8Array(ints)
-      }
-      break
-    default:
-      if (hasBuffer) {
-        if (Buffer.isBuffer(data)) return data
-      }
-      if (hasTypedArrays) {
-        if (ArrayBuffer.isView(data)) {
-          return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-        }
-        if (data instanceof ArrayBuffer) {
-          return new Uint8Array(data)
-        }
-      }
-      throw new Error(`Unrecognized data type ${typeof data}: ${data}`)
-  }
-  throw Error(`Internal error: no buffer conversion for ${typeof data}: ${data}`)
 }
 
 function mirror (data, width) {
@@ -221,6 +253,7 @@ function noop (value) {}
 module.exports = {
   CRC,
   crc,
+  makeBufferConverter,
   models,
   crc1: noop,
   crc6: noop,

--- a/polycrc.js
+++ b/polycrc.js
@@ -131,15 +131,26 @@ if (!hasTypedArrays && !hasBuffer) {
 function validate_buffer (data) {
   switch (typeof data) {
     case 'number':
+      if (!Number.isSafeInteger(data) || data < 0) {
+        throw Error(`number data must be an nonnegative safe integer, not ${data}`);
+      }
+      // Unpack the number into a big-endian array of 8-bit values.
+      const bytes = [];
+      while (data > 0) {
+        bytes.unshift(data % 256);
+        data = Math.floor(data / 256);
+      }
+      // For compatibility with polycrc@1.0.0, we make it at least 4 bytes in length.
+      // If we have a number more than 32 bits, we will have more bytes already.
+      while (bytes.length < 4) {
+        bytes.unshift(0);
+      }
+      // Just create a buffer from that array.
       if (hasBuffer) {
-        const buffer = Buffer.alloc(4)
-        buffer.writeUInt32BE(data)
-        return buffer
-      } else if (hasTypedArrays) {
-        const buffer = new Uint8Array(4)
-        const dv = new DataView(buffer.buffer)
-        dv.setUint32(0, data)
-        return buffer
+        return Buffer.from(bytes);
+      }
+      if (hasTypedArrays) {
+        return Uint8Array.from(bytes);
       }
       break
     case 'string':

--- a/polycrc.js
+++ b/polycrc.js
@@ -132,7 +132,7 @@ function fixUpNumberBytes (bytes) {
   // For compatibility with polycrc@1.0.0, we make it at least 4 bytes in length.
   // If we have a number more than 32 bits, we will have more bytes already.
   while (bytes.length < 4) {
-    bytes.unshift(0);
+    bytes.unshift(0)
   }
 }
 
@@ -140,21 +140,21 @@ function validate_buffer (data) {
   switch (typeof data) {
     case 'number':
       if (!Number.isSafeInteger(data) || data < 0) {
-        throw Error(`number data must be a nonnegative safe integer, not ${data}`);
+        throw Error(`number data must be a nonnegative safe integer, not ${data}`)
       }
       // Unpack the number into a big-endian array of 8-bit values.
-      const bytes = [];
+      const bytes = []
       while (data > 0) {
-        bytes.unshift(data % 256);
-        data = Math.floor(data / 256);
+        bytes.unshift(data % 256)
+        data = Math.floor(data / 256)
       }
       fixUpNumberBytes(bytes)
       // Just create a buffer from that array.
       if (hasBuffer) {
-        return Buffer.from(bytes);
+        return Buffer.from(bytes)
       }
       if (hasTypedArrays) {
-        return Uint8Array.from(bytes);
+        return Uint8Array.from(bytes)
       }
       break
     case 'string':

--- a/polycrc.js
+++ b/polycrc.js
@@ -154,11 +154,11 @@ function validate_buffer (data) {
         if (Buffer.isBuffer(data)) return data
       }
       if (hasTypedArrays) {
+        if (ArrayBuffer.isView(data)) {
+          return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        }
         if (data instanceof ArrayBuffer) {
           return new Uint8Array(data)
-        }
-        if (ArrayBuffer.isView(data)) {
-          return new Uint8Array(data.buffer)
         }
       }
       throw new Error(`Unrecognized data type ${typeof data}: ${data}`)

--- a/test/crc.test.js
+++ b/test/crc.test.js
@@ -3,7 +3,7 @@ const polycrc = require('../polycrc')
 
 const string = 'Hello, world!'
 
-tape('CRC of a string', function (t) {
+function checkString (t, string) {
   t.same(polycrc.crc1(string), 1)
   t.same(polycrc.crc6(string), 47)
   t.same(polycrc.crc8(string), 188)
@@ -12,12 +12,10 @@ tape('CRC of a string', function (t) {
   t.same(polycrc.crc24(string), 1826690)
   t.same(polycrc.crc32(string), 3957769958)
   t.same(polycrc.crc32c(string), 3365996261)
-  t.end()
-})
+}
 
 const number = 12345
-
-tape('CRC of a number', function (t) {
+function checkNumber (t, number) {
   t.same(polycrc.crc1(number), 0)
   t.same(polycrc.crc6(number), 3)
   t.same(polycrc.crc8(number), 86)
@@ -26,50 +24,58 @@ tape('CRC of a number', function (t) {
   t.same(polycrc.crc24(number), 9061093)
   t.same(polycrc.crc32(number), 2701615591)
   t.same(polycrc.crc32c(number), 1081658169)
+}
+
+const large = 12345 + Math.pow(2, 52)
+function checkLarge (t, large) {
+  t.same(polycrc.crc1(large), 1)
+  t.same(polycrc.crc6(large), 8)
+  t.same(polycrc.crc8(large), 133)
+  t.same(polycrc.crc10(large), 964)
+  t.same(polycrc.crc16(large), 54213)
+  t.same(polycrc.crc24(large), 11462589)
+  t.same(polycrc.crc32(large), 2062679371)
+  t.same(polycrc.crc32c(large), 796528693)
+}
+
+const buf = Buffer.from([1, 2, 3])
+function checkBuf (t, buf) {
+  t.same(polycrc.crc1(buf), 0)
+  t.same(polycrc.crc6(buf), 20)
+  t.same(polycrc.crc8(buf), 72)
+  t.same(polycrc.crc10(buf), 928)
+  t.same(polycrc.crc16(buf), 41232)
+  t.same(polycrc.crc24(buf), 6775187)
+  t.same(polycrc.crc32(buf), 1438416925)
+  t.same(polycrc.crc32c(buf), 4046516766)
+}
+
+tape('CRC of a string', function (t) {
+  checkString(t, string)
   t.end()
 })
 
-tape('CRC of a number > 32-bit', function (t) {
-  const number = 12345 + 2**52
-  t.same(polycrc.crc1(number), 1)
-  t.same(polycrc.crc6(number), 8)
-  t.same(polycrc.crc8(number), 133)
-  t.same(polycrc.crc10(number), 964)
-  t.same(polycrc.crc16(number), 54213)
-  t.same(polycrc.crc24(number), 11462589)
-  t.same(polycrc.crc32(number), 2062679371)
-  t.same(polycrc.crc32c(number), 796528693)
-  t.throws(() => polycrc.crc1(2**54), /must be a nonnegative safe integer/)
+tape('CRC of a number', function (t) {
+  checkNumber(t, number)
+  t.end()
+})
 
+tape('CRC of a large number', function (t) {
+  checkLarge(t, large)
+  t.throws(() => polycrc.crc1(2**54), /must be a nonnegative safe integer/)
   t.end()
 })
 
 tape('CRC of a 32-bit BigInt', function (t) {
   if (typeof BigInt !== 'undefined') {
-    const number = BigInt(12345)
-    t.same(polycrc.crc1(number), 0)
-    t.same(polycrc.crc6(number), 3)
-    t.same(polycrc.crc8(number), 86)
-    t.same(polycrc.crc10(number), 201)
-    t.same(polycrc.crc16(number), 4820)
-    t.same(polycrc.crc24(number), 9061093)
-    t.same(polycrc.crc32(number), 2701615591)
-    t.same(polycrc.crc32c(number), 1081658169)
+    checkNumber(t, BigInt(number))
   }
   t.end()
 })
 
 tape('CRC of a >32-bit BigInt', function (t) {
   if (typeof BigInt !== 'undefined') {
-    const number = BigInt(12345 + 2**52)
-    t.same(polycrc.crc1(number), 1)
-    t.same(polycrc.crc6(number), 8)
-    t.same(polycrc.crc8(number), 133)
-    t.same(polycrc.crc10(number), 964)
-    t.same(polycrc.crc16(number), 54213)
-    t.same(polycrc.crc24(number), 11462589)
-    t.same(polycrc.crc32(number), 2062679371)
-    t.same(polycrc.crc32c(number), 796528693)
+    checkLarge(t, BigInt(large))
   }
   t.end()
 })
@@ -83,29 +89,13 @@ tape('CRC of a really BigInt', function (t) {
     const bignum = BigInt(`0x${hex}`)
 
     // Validate the same CRCs as the string.
-    t.same(polycrc.crc1(bignum), 1)
-    t.same(polycrc.crc6(bignum), 47)
-    t.same(polycrc.crc8(bignum), 188)
-    t.same(polycrc.crc10(bignum), 926)
-    t.same(polycrc.crc16(bignum), 39498)
-    t.same(polycrc.crc24(bignum), 1826690)
-    t.same(polycrc.crc32(bignum), 3957769958)
-    t.same(polycrc.crc32c(bignum), 3365996261)
+    checkString(t, bignum)
   }
   t.end()
 })
 
-const buf = Buffer.from([1, 2, 3])
-
 tape('CRC of a buffer', function (t) {
-  t.same(polycrc.crc1(buf), 0)
-  t.same(polycrc.crc6(buf), 20)
-  t.same(polycrc.crc8(buf), 72)
-  t.same(polycrc.crc10(buf), 928)
-  t.same(polycrc.crc16(buf), 41232)
-  t.same(polycrc.crc24(buf), 6775187)
-  t.same(polycrc.crc32(buf), 1438416925)
-  t.same(polycrc.crc32c(buf), 4046516766)
+  checkBuf(t, buf)
   t.end()
 })
 
@@ -113,14 +103,7 @@ tape('CRC of an ArrayBuffer', function (t) {
   if (typeof ArrayBuffer !== 'undefined') {
     const ubuf = new Uint8Array(buf.values())
     const abuf = ubuf.buffer
-    t.same(polycrc.crc1(abuf), 0)
-    t.same(polycrc.crc6(abuf), 20)
-    t.same(polycrc.crc8(abuf), 72)
-    t.same(polycrc.crc10(abuf), 928)
-    t.same(polycrc.crc16(abuf), 41232)
-    t.same(polycrc.crc24(abuf), 6775187)
-    t.same(polycrc.crc32(abuf), 1438416925)
-    t.same(polycrc.crc32c(abuf), 4046516766)
+    checkBuf(t, abuf)
   }
   t.end()
 })
@@ -128,14 +111,7 @@ tape('CRC of an ArrayBuffer', function (t) {
 tape('CRC of a Uint8Array', function (t) {
   if (typeof Uint8Array !== 'undefined') {
     const ubuf = new Uint8Array(buf.values())
-    t.same(polycrc.crc1(ubuf), 0)
-    t.same(polycrc.crc6(ubuf), 20)
-    t.same(polycrc.crc8(ubuf), 72)
-    t.same(polycrc.crc10(ubuf), 928)
-    t.same(polycrc.crc16(ubuf), 41232)
-    t.same(polycrc.crc24(ubuf), 6775187)
-    t.same(polycrc.crc32(ubuf), 1438416925)
-    t.same(polycrc.crc32c(ubuf), 4046516766)
+    checkBuf(t, ubuf)
   }
   t.end()
 })
@@ -144,14 +120,7 @@ tape('CRC of a DataView', function (t) {
   if (typeof DataView !== 'undefined') {
     const wideBuf = new Uint8Array([0, 1, 2, 3, 4])
     const buf = new DataView(wideBuf.buffer, 1, 3)
-    t.same(polycrc.crc1(buf), 0)
-    t.same(polycrc.crc6(buf), 20)
-    t.same(polycrc.crc8(buf), 72)
-    t.same(polycrc.crc10(buf), 928)
-    t.same(polycrc.crc16(buf), 41232)
-    t.same(polycrc.crc24(buf), 6775187)
-    t.same(polycrc.crc32(buf), 1438416925)
-    t.same(polycrc.crc32c(buf), 4046516766)
+    checkBuf(t, buf)
   }
   t.end()
 })

--- a/test/crc.test.js
+++ b/test/crc.test.js
@@ -29,6 +29,72 @@ tape('CRC of a number', function (t) {
   t.end()
 })
 
+tape('CRC of a number > 32-bit', function (t) {
+  const number = 12345 + 2**52
+  t.same(polycrc.crc1(number), 1)
+  t.same(polycrc.crc6(number), 8)
+  t.same(polycrc.crc8(number), 133)
+  t.same(polycrc.crc10(number), 964)
+  t.same(polycrc.crc16(number), 54213)
+  t.same(polycrc.crc24(number), 11462589)
+  t.same(polycrc.crc32(number), 2062679371)
+  t.same(polycrc.crc32c(number), 796528693)
+  t.throws(() => polycrc.crc1(2**54), /must be a nonnegative safe integer/)
+
+  t.end()
+})
+
+tape('CRC of a 32-bit BigInt', function (t) {
+  if (typeof BigInt !== 'undefined') {
+    const number = BigInt(12345)
+    t.same(polycrc.crc1(number), 0)
+    t.same(polycrc.crc6(number), 3)
+    t.same(polycrc.crc8(number), 86)
+    t.same(polycrc.crc10(number), 201)
+    t.same(polycrc.crc16(number), 4820)
+    t.same(polycrc.crc24(number), 9061093)
+    t.same(polycrc.crc32(number), 2701615591)
+    t.same(polycrc.crc32c(number), 1081658169)
+  }
+  t.end()
+})
+
+tape('CRC of a >32-bit BigInt', function (t) {
+  if (typeof BigInt !== 'undefined') {
+    const number = BigInt(12345 + 2**52)
+    t.same(polycrc.crc1(number), 1)
+    t.same(polycrc.crc6(number), 8)
+    t.same(polycrc.crc8(number), 133)
+    t.same(polycrc.crc10(number), 964)
+    t.same(polycrc.crc16(number), 54213)
+    t.same(polycrc.crc24(number), 11462589)
+    t.same(polycrc.crc32(number), 2062679371)
+    t.same(polycrc.crc32c(number), 796528693)
+  }
+  t.end()
+})
+
+tape('CRC of a really BigInt', function (t) {
+  if (typeof BigInt !== 'undefined') {
+    // Convert the string to a big-endian bigint.
+    const bytes = new TextEncoder('utf-8').encode(string)
+    const ints = [...bytes.values()].map(b => b.toString(16).padStart(2, '0'))
+    const hex = ints.join('')
+    const bignum = BigInt(`0x${hex}`)
+
+    // Validate the same CRCs as the string.
+    t.same(polycrc.crc1(bignum), 1)
+    t.same(polycrc.crc6(bignum), 47)
+    t.same(polycrc.crc8(bignum), 188)
+    t.same(polycrc.crc10(bignum), 926)
+    t.same(polycrc.crc16(bignum), 39498)
+    t.same(polycrc.crc24(bignum), 1826690)
+    t.same(polycrc.crc32(bignum), 3957769958)
+    t.same(polycrc.crc32c(bignum), 3365996261)
+  }
+  t.end()
+})
+
 const buf = Buffer.from([1, 2, 3])
 
 tape('CRC of a buffer', function (t) {

--- a/test/crc.test.js
+++ b/test/crc.test.js
@@ -42,3 +42,50 @@ tape('CRC of a buffer', function (t) {
   t.same(polycrc.crc32c(buf), 4046516766)
   t.end()
 })
+
+tape('CRC of an ArrayBuffer', function (t) {
+  if (typeof ArrayBuffer !== 'undefined') {
+    const ubuf = new Uint8Array(buf.values())
+    const abuf = ubuf.buffer
+    t.same(polycrc.crc1(abuf), 0)
+    t.same(polycrc.crc6(abuf), 20)
+    t.same(polycrc.crc8(abuf), 72)
+    t.same(polycrc.crc10(abuf), 928)
+    t.same(polycrc.crc16(abuf), 41232)
+    t.same(polycrc.crc24(abuf), 6775187)
+    t.same(polycrc.crc32(abuf), 1438416925)
+    t.same(polycrc.crc32c(abuf), 4046516766)
+  }
+  t.end()
+})
+
+tape('CRC of a Uint8Array', function (t) {
+  if (typeof Uint8Array !== 'undefined') {
+    const ubuf = new Uint8Array(buf.values())
+    t.same(polycrc.crc1(ubuf), 0)
+    t.same(polycrc.crc6(ubuf), 20)
+    t.same(polycrc.crc8(ubuf), 72)
+    t.same(polycrc.crc10(ubuf), 928)
+    t.same(polycrc.crc16(ubuf), 41232)
+    t.same(polycrc.crc24(ubuf), 6775187)
+    t.same(polycrc.crc32(ubuf), 1438416925)
+    t.same(polycrc.crc32c(ubuf), 4046516766)
+  }
+  t.end()
+})
+
+tape('CRC of a DataView', function (t) {
+  if (typeof DataView !== 'undefined') {
+    const wideBuf = new Uint8Array([0, 1, 2, 3, 4])
+    const buf = new DataView(wideBuf.buffer, 1, 3)
+    t.same(polycrc.crc1(buf), 0)
+    t.same(polycrc.crc6(buf), 20)
+    t.same(polycrc.crc8(buf), 72)
+    t.same(polycrc.crc10(buf), 928)
+    t.same(polycrc.crc16(buf), 41232)
+    t.same(polycrc.crc24(buf), 6775187)
+    t.same(polycrc.crc32(buf), 1438416925)
+    t.same(polycrc.crc32c(buf), 4046516766)
+  }
+  t.end()
+})

--- a/test/crc.test.js
+++ b/test/crc.test.js
@@ -3,124 +3,139 @@ const polycrc = require('../polycrc')
 
 const string = 'Hello, world!'
 
-function checkString (t, string) {
-  t.same(polycrc.crc1(string), 1)
-  t.same(polycrc.crc6(string), 47)
-  t.same(polycrc.crc8(string), 188)
-  t.same(polycrc.crc10(string), 926)
-  t.same(polycrc.crc16(string), 39498)
-  t.same(polycrc.crc24(string), 1826690)
-  t.same(polycrc.crc32(string), 3957769958)
-  t.same(polycrc.crc32c(string), 3365996261)
+function checkString (t, calcs, string) {
+  t.same(calcs.crc1(string), 1)
+  t.same(calcs.crc6(string), 47)
+  t.same(calcs.crc8(string), 188)
+  t.same(calcs.crc10(string), 926)
+  t.same(calcs.crc16(string), 39498)
+  t.same(calcs.crc24(string), 1826690)
+  t.same(calcs.crc32(string), 3957769958)
+  t.same(calcs.crc32c(string), 3365996261)
 }
 
 const number = 12345
-function checkNumber (t, number) {
-  t.same(polycrc.crc1(number), 0)
-  t.same(polycrc.crc6(number), 3)
-  t.same(polycrc.crc8(number), 86)
-  t.same(polycrc.crc10(number), 201)
-  t.same(polycrc.crc16(number), 4820)
-  t.same(polycrc.crc24(number), 9061093)
-  t.same(polycrc.crc32(number), 2701615591)
-  t.same(polycrc.crc32c(number), 1081658169)
+function checkNumber (t, calcs, number) {
+  t.same(calcs.crc1(number), 0)
+  t.same(calcs.crc6(number), 3)
+  t.same(calcs.crc8(number), 86)
+  t.same(calcs.crc10(number), 201)
+  t.same(calcs.crc16(number), 4820)
+  t.same(calcs.crc24(number), 9061093)
+  t.same(calcs.crc32(number), 2701615591)
+  t.same(calcs.crc32c(number), 1081658169)
 }
 
 const large = 12345 + Math.pow(2, 52)
-function checkLarge (t, large) {
-  t.same(polycrc.crc1(large), 1)
-  t.same(polycrc.crc6(large), 8)
-  t.same(polycrc.crc8(large), 133)
-  t.same(polycrc.crc10(large), 964)
-  t.same(polycrc.crc16(large), 54213)
-  t.same(polycrc.crc24(large), 11462589)
-  t.same(polycrc.crc32(large), 2062679371)
-  t.same(polycrc.crc32c(large), 796528693)
+function checkLarge (t, calcs, large) {
+  t.same(calcs.crc1(large), 1)
+  t.same(calcs.crc6(large), 8)
+  t.same(calcs.crc8(large), 133)
+  t.same(calcs.crc10(large), 964)
+  t.same(calcs.crc16(large), 54213)
+  t.same(calcs.crc24(large), 11462589)
+  t.same(calcs.crc32(large), 2062679371)
+  t.same(calcs.crc32c(large), 796528693)
 }
 
 const buf = Buffer.from([1, 2, 3])
-function checkBuf (t, buf) {
-  t.same(polycrc.crc1(buf), 0)
-  t.same(polycrc.crc6(buf), 20)
-  t.same(polycrc.crc8(buf), 72)
-  t.same(polycrc.crc10(buf), 928)
-  t.same(polycrc.crc16(buf), 41232)
-  t.same(polycrc.crc24(buf), 6775187)
-  t.same(polycrc.crc32(buf), 1438416925)
-  t.same(polycrc.crc32c(buf), 4046516766)
+function checkBuf (t, calcs, buf) {
+  t.same(calcs.crc1(buf), 0)
+  t.same(calcs.crc6(buf), 20)
+  t.same(calcs.crc8(buf), 72)
+  t.same(calcs.crc10(buf), 928)
+  t.same(calcs.crc16(buf), 41232)
+  t.same(calcs.crc24(buf), 6775187)
+  t.same(calcs.crc32(buf), 1438416925)
+  t.same(calcs.crc32c(buf), 4046516766)
 }
 
-tape('CRC of a string', function (t) {
-  checkString(t, string)
-  t.end()
-})
-
-tape('CRC of a number', function (t) {
-  checkNumber(t, number)
-  t.end()
-})
-
-tape('CRC of a large number', function (t) {
-  checkLarge(t, large)
-  t.throws(() => polycrc.crc1(2**54), /must be a nonnegative safe integer/)
-  t.end()
-})
-
-tape('CRC of a 32-bit BigInt', function (t) {
-  if (typeof BigInt !== 'undefined') {
-    checkNumber(t, BigInt(number))
+for (const preferTypedArray of [undefined, false, true]) {
+  let calcs = polycrc
+  let desc = 'default'
+  if (preferTypedArray !== undefined) {
+    calcs = {}
+    desc = preferTypedArray ? 'TypedArray' : 'Buffer'
+    for (let name in polycrc.models) {
+      let model = polycrc.models[name]
+      // Replace the converter with an explicit preference.
+      model.converter = polycrc.makeBufferConverter(preferTypedArray)
+      calcs[name] = model.calculate.bind(model)
+    }
   }
-  t.end()
-})
 
-tape('CRC of a >32-bit BigInt', function (t) {
-  if (typeof BigInt !== 'undefined') {
-    checkLarge(t, BigInt(large))
-  }
-  t.end()
-})
+  tape(`${desc} - CRC of a string`, function (t) {
+    checkString(t, calcs, string)
+    t.end()
+  })
 
-tape('CRC of a really BigInt', function (t) {
-  if (typeof BigInt !== 'undefined') {
-    // Convert the string to a big-endian bigint.
-    const bytes = new TextEncoder('utf-8').encode(string)
-    const ints = [...bytes.values()].map(b => b.toString(16).padStart(2, '0'))
-    const hex = ints.join('')
-    const bignum = BigInt(`0x${hex}`)
+  tape(`${desc} - CRC of a number`, function (t) {
+    checkNumber(t, calcs, number)
+    t.end()
+  })
 
-    // Validate the same CRCs as the string.
-    checkString(t, bignum)
-  }
-  t.end()
-})
+  tape(`${desc} - CRC of a large number`, function (t) {
+    checkLarge(t, calcs, large)
+    t.throws(() => polycrc.crc1(2**54), /must be a nonnegative safe integer/)
+    t.end()
+  })
 
-tape('CRC of a buffer', function (t) {
-  checkBuf(t, buf)
-  t.end()
-})
+  tape(`${desc} - CRC of a 32-bit BigInt`, function (t) {
+    if (typeof BigInt !== 'undefined') {
+      checkNumber(t, calcs, BigInt(number))
+    }
+    t.end()
+  })
 
-tape('CRC of an ArrayBuffer', function (t) {
-  if (typeof ArrayBuffer !== 'undefined') {
-    const ubuf = new Uint8Array(buf.values())
-    const abuf = ubuf.buffer
-    checkBuf(t, abuf)
-  }
-  t.end()
-})
+  tape(`${desc} - CRC of a >32-bit BigInt`, function (t) {
+    if (typeof BigInt !== 'undefined') {
+      checkLarge(t, calcs, BigInt(large))
+    }
+    t.end()
+  })
 
-tape('CRC of a Uint8Array', function (t) {
-  if (typeof Uint8Array !== 'undefined') {
-    const ubuf = new Uint8Array(buf.values())
-    checkBuf(t, ubuf)
-  }
-  t.end()
-})
+  tape(`${desc} - CRC of a really BigInt`, function (t) {
+    if (typeof BigInt !== 'undefined') {
+      // Convert the string to a big-endian bigint.
+      const bytes = new TextEncoder('utf-8').encode(string)
+      const ints = [...bytes.values()].map(b => b.toString(16).padStart(2, '0'))
+      const hex = ints.join('')
+      const bignum = BigInt(`0x${hex}`)
 
-tape('CRC of a DataView', function (t) {
-  if (typeof DataView !== 'undefined') {
-    const wideBuf = new Uint8Array([0, 1, 2, 3, 4])
-    const buf = new DataView(wideBuf.buffer, 1, 3)
-    checkBuf(t, buf)
-  }
-  t.end()
-})
+      // Validate the same CRCs as the string.
+      checkString(t, calcs, bignum)
+    }
+    t.end()
+  })
+
+  tape(`${desc} - CRC of a buffer`, function (t) {
+    checkBuf(t, calcs, buf)
+    t.end()
+  })
+
+  tape(`${desc} - CRC of an ArrayBuffer`, function (t) {
+    if (typeof ArrayBuffer !== 'undefined') {
+      const ubuf = new Uint8Array(buf.values())
+      const abuf = ubuf.buffer
+      checkBuf(t, calcs, abuf)
+    }
+    t.end()
+  })
+
+  tape(`${desc} - CRC of a Uint8Array`, function (t) {
+    if (typeof Uint8Array !== 'undefined') {
+      const ubuf = new Uint8Array(buf.values())
+      checkBuf(t, calcs, ubuf)
+    }
+    t.end()
+  })
+
+  tape(`${desc} - CRC of a DataView`, function (t) {
+    if (typeof DataView !== 'undefined') {
+      const wideBuf = new Uint8Array([0, 1, 2, 3, 4])
+      const buf = new DataView(wideBuf.buffer, 1, 3)
+      checkBuf(t, calcs, buf)
+    }
+    t.end()
+  })
+}


### PR DESCRIPTION
This PR extends the range of numbers directly convertible to a buffer from 32 bits to 53 bits.

Benchmarking shows that the manual unpacking of the safe integer into bytes doesn't affect the rest of polycrc performance.
